### PR TITLE
Bump octodns to 0.9.17 and ovh to 1.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: x64
       - name: CI setup.py
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # Tested versions based on dates in https://devguide.python.org/devcycle/#end-of-life-branches
-        # 3.10 not yet supported, see https://github.com/octodns/octodns-ovh/issues/2
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PyYAML==6.0
 dnspython==2.2.1
 fqdn==1.5.1
 natsort==8.1.0
-octodns==0.9.16
-ovh==0.5.0
+octodns==0.9.17
+ovh==1.0.0
 python-dateutil==2.8.2
 six==1.16.0


### PR DESCRIPTION
Bump ovh version to 1.0.0 to achieve python 3.10 support.