### PR TITLE
Release 0.0.2 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.2 - 2022-11-20 -
+
+* Remove extra . on the end of SRV record targets
+
 ## v0.0.1 - 2022-01-13 - Moving
 
 #### Nothworthy Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.2 - 2022-11-20 -
+## v0.0.2 - 2022-11-20 - Less dots
 
 * Remove extra . on the end of SRV record targets
 

--- a/octodns_ovh/__init__.py
+++ b/octodns_ovh/__init__.py
@@ -13,7 +13,7 @@ from ovh import ResourceNotFoundError
 from octodns.record import Record
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class OvhProvider(BaseProvider):


### PR DESCRIPTION
## v0.0.2 - 2022-11-20 - Less dots

* Remove extra . on the end of SRV record targets

/cc Fixes https://github.com/octodns/octodns-ovh/issues/15