### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_provider_octodns_ovh.py
+++ b/tests/test_provider_octodns_ovh.py
@@ -463,6 +463,7 @@ class TestOvhProvider(TestCase):
             'application_key',
             'application_secret',
             'consumer_key',
+            strict_supports=False,
         )
 
         desired = Zone('unit.tests.', [])


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957