### PR TITLE
Indicate support of root NS records in OvhProvider

### DIFF
--- a/octodns_ovh/__init__.py
+++ b/octodns_ovh/__init__.py
@@ -20,6 +20,7 @@ class OvhProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     ZONE_NOT_FOUND_MESSAGE = 'This service does not exist'
+    SUPPORTS_ROOT_NS = True
 
     # This variable is also used in populate method to filter which OVH record
     # types are supported by octodns
@@ -40,10 +41,6 @@ class OvhProvider(BaseProvider):
             'TXT',
         )
     )
-
-    @property
-    def SUPPORTS_ROOT_NS(self):
-        return True
 
     def __init__(
         self,


### PR DESCRIPTION
I had to deploy changes to my workplace's DNS zones in OVH and noticed that since octodns 1.0.0, providers have to indicate wether they support changes to root NS records.

As the configuration we used before the update includes root NS records, we started to encounter the error after the update.

Rolling back to 0.9.21 fixes the issue and we are allowed to deploy and check changes to our zones normally, which led me to think the support is already there and is not advertised by the module.

If I am wrong/not seeing something or any kind of modification is needed, please tell me, I am open to implementing changes to fix our deployments and allow us to update octodns on our workstations.

I ran the tests and they appear to be passing normally, if additional tests are needed for this to be merged please let me know.

Thank you very much for your work !