### PR TITLE
Pull python versions from octodns/octodns/.ci-config.json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       run: |
         {
           echo 'json<<EOF'
-          curl -L https://github.com/octodns/octodns/raw/python-matrix-json/.ci-config.json
+          curl -L https://github.com/octodns/octodns/raw/main/.ci-config.json
           echo EOF
         } >> $GITHUB_OUTPUT
   ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,25 @@ name: octoDNS OvhProvider
 on: [pull_request]
 
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.load.outputs.json }}
+    steps:
+    - id: load
+      run: |
+        {
+          echo 'json<<EOF'
+          curl -L https://github.com/octodns/octodns/raw/python-matrix-json/.ci-config.json
+          echo EOF
+        } >> $GITHUB_OUTPUT
   ci:
+    needs: config
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{fromJson(vars.PYTHON_VERSIONS_ACTIVE)}}
+        python-version: ${{ fromJson(needs.config.outputs.json).python_versions_active }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup python
@@ -19,13 +32,14 @@ jobs:
         run: |
           ./script/cibuild
   setup-py:
+    needs: config
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ vars.PYTHON_VERSION_CURRENT }}
+          python-version: ${{ fromJson(needs.config.outputs.json).python_version_current }}
           architecture: x64
       - name: CI setup.py
         run: |


### PR DESCRIPTION
So variables are apparently no different than secrets and are not available to
forks CI runs. This switches to use a file, octodns/octodns/.ci-config.json
instead. It's not as clean, but it should work.

/cc https://github.com/octodns/octodns/pull/1084 for more information