### PR TITLE
Version 1.2.0 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/352cdbf948124e9782b4106966a24e57.md
+++ b/.changelog/352cdbf948124e9782b4106966a24e57.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add SVCB and HTTPS record support

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/4afc0a4c719143bf83340cd377b73f31.md
+++ b/.changelog/4afc0a4c719143bf83340cd377b73f31.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/6d863624afe94557bf8dd04d8ca76b28.md
+++ b/.changelog/6d863624afe94557bf8dd04d8ca76b28.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/79952b5de0b14c45ad50e0273a88480d.md
+++ b/.changelog/79952b5de0b14c45ad50e0273a88480d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix ns1 type-o in script/format

--- a/.changelog/7c54e493231e447fab561a26864aaef8.md
+++ b/.changelog/7c54e493231e447fab561a26864aaef8.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/915badd98e0b46a7ac84e3aa3a1dee6b.md
+++ b/.changelog/915badd98e0b46a7ac84e3aa3a1dee6b.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/ab82766e973f42a088ddc2be22751ca8.md
+++ b/.changelog/ab82766e973f42a088ddc2be22751ca8.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/b90a3253833c465da12d02a0f230389d.md
+++ b/.changelog/b90a3253833c465da12d02a0f230389d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/d7e2992a478343a993c2db2f39768b35.md
+++ b/.changelog/d7e2992a478343a993c2db2f39768b35.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/dd1ace2e32454217a087ad96753f5243.md
+++ b/.changelog/dd1ace2e32454217a087ad96753f5243.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0 - 2026-04-03
+
+Minor:
+* Add SVCB and HTTPS record support - [#62](https://github.com/octodns/octodns-ovh/pull/62)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#50](https://github.com/octodns/octodns-ovh/pull/50)
+
 ## v1.1.0 - 2025-07-01 - Normal TXT
 
 * Normalize TXT records to prevent unnecessary updates

--- a/octodns_ovh/__init__.py
+++ b/octodns_ovh/__init__.py
@@ -15,7 +15,7 @@ from octodns.record import Record
 from octodns.record.svcb import SvcbValue
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.1.0'
+__version__ = __VERSION__ = '1.2.0'
 
 
 class OvhProvider(BaseProvider):


### PR DESCRIPTION
## 1.2.0 - 2026-04-03

Minor:
* Add SVCB and HTTPS record support - [#62](https://github.com/octodns/octodns-ovh/pull/62)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#50](https://github.com/octodns/octodns-ovh/pull/50)

