### PR TITLE
Fix SSHFP fingerprint type and length mismatches

### DIFF
--- a/.changelog/0a23031c5b9e4533a69ba868546404ba.md
+++ b/.changelog/0a23031c5b9e4533a69ba868546404ba.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Fix SSHFP fingerprint type and length mismatches

--- a/tests/test_provider_octodns_ovh.py
+++ b/tests/test_provider_octodns_ovh.py
@@ -252,7 +252,7 @@ class TestOvhProvider(TestCase):
         {
             'fieldType': 'SSHFP',
             'ttl': 1100,
-            'target': '1 1 bf6b6825d2977c511a475bbefb88aad54a92ac73 ',
+            'target': '1 1 bf6b6825d2977c511a475bbefb88aad54a92ac73',
             'subDomain': '',
             'id': 14,
         }


### PR DESCRIPTION
/cc https://github.com/octodns/octodns/pull/1372 which added the validation