### PR TITLE
Ignore octoDNS 2.0 deprecation warnings

### DIFF
--- a/.changelog/ed300b39df6f478a9d0c3d9545574c5b.md
+++ b/.changelog/ed300b39df6f478a9d0c3d9545574c5b.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Ignore octoDNS 2.0 deprecation warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,5 +82,6 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
+    'ignore:.*DEPRECATED.*2.0',
 ]
 pythonpath = "."


### PR DESCRIPTION
Ignore deprecation warnings for APIs scheduled for removal in octoDNS 2.0 while retaining warning-as-error behavior for all other warnings.

These warnings will be addressed when this module migrates to the octoDNS 2.x APIs.

/cc octodns/octodns#1452 Validate downstream compatibility for the RDATA API migration